### PR TITLE
Feature/issue 35

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/UserInfoController.java
+++ b/src/main/java/com/dudoji/spring/controller/UserInfoController.java
@@ -5,10 +5,13 @@ import com.dudoji.spring.service.UserInfoService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.security.Principal;
 
 /**
  * UserInfoController
@@ -19,25 +22,58 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("api/user/info")
+@PreAuthorize("isAuthenticated()")
 public class UserInfoController {
 
     @Autowired
     private UserInfoService userInfoService;
 
     /**
+     * Helper method to fetch a single String value for the current user
+     * @param principal JWT Token
+     * @param fetcher getter func
+     * @return HTTP 200 + Real Data
+     */
+    private ResponseEntity<String> fetchForCurrentUser(
+            @AuthenticationPrincipal PrincipalDetails principal,
+            java.util.function.Function<Long, String> fetcher
+    ) {
+        String result = fetcher.apply(principal.getUid());
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+    /**
      * Retrieve the profile image of the authenticated user.
      * @param principal JWT token
      * @return User's profile image url
      */
-    @GetMapping("/get/profile_image")
+    @GetMapping("/get/profile-image")
     public ResponseEntity<String> getProfileImage(
         @AuthenticationPrincipal PrincipalDetails principal
     ) {
-        if (principal == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Not authenticated");
-        }
-        String result = userInfoService.getProfileImage(principal.getUid());
+        return fetchForCurrentUser(principal, userInfoService::getProfileImage);
+    }
 
-        return ResponseEntity.status(HttpStatus.OK).body(result);
+    /**
+     * Returns the username of the authenticated user
+     * @param principal JWT token
+     * @return Username as String
+     */
+    @GetMapping("/get/name")
+    public ResponseEntity<String> getName(
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        return fetchForCurrentUser(principal, userInfoService::getUsername);
+    }
+
+    /**
+     * Returns the email
+     * @param principal JWT Token
+     * @return Email as String
+     */
+    @GetMapping("/get/email")
+    public ResponseEntity<String> getEmail(
+            @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        return fetchForCurrentUser(principal, userInfoService::getEmail);
     }
 }

--- a/src/main/java/com/dudoji/spring/controller/UserInfoController.java
+++ b/src/main/java/com/dudoji/spring/controller/UserInfoController.java
@@ -1,0 +1,43 @@
+package com.dudoji.spring.controller;
+
+import com.dudoji.spring.models.domain.PrincipalDetails;
+import com.dudoji.spring.service.UserInfoService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * UserInfoController
+ * REST controller that exposes endpoints for user information operations
+ * <ul>
+ *     <li>Retrieve authenticated user's profile image</li>
+ * </ul>
+ */
+@RestController
+@RequestMapping("api/user/info")
+public class UserInfoController {
+
+    @Autowired
+    private UserInfoService userInfoService;
+
+    /**
+     * Retrieve the profile image of the authenticated user.
+     * @param principal JWT token
+     * @return User's profile image url
+     */
+    @GetMapping("/get/profile_image")
+    public ResponseEntity<String> getProfileImage(
+        @AuthenticationPrincipal PrincipalDetails principal
+    ) {
+        if (principal == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("Not authenticated");
+        }
+        String result = userInfoService.getProfileImage(principal.getUid());
+
+        return ResponseEntity.status(HttpStatus.OK).body(result);
+    }
+}

--- a/src/main/java/com/dudoji/spring/models/dao/UserDao.java
+++ b/src/main/java/com/dudoji/spring/models/dao/UserDao.java
@@ -15,11 +15,11 @@ public class UserDao {
     private DBConnection dbConnection;
 
     private static String GET_USER_BY_ID =
-            "select name, email, created_at, role from \"User\" where id=?";
+            "select name, email, created_at, role, profile_image from \"User\" where id=?";
     private static String GET_USER_BY_NAME =
             "SELECT id, email, created_at, role, password FROM \"User\" WHERE name=?";
-    private static String GET_USER_BY_NAME_AND_EMAIL =
-            "SELECT id, email, created_at, role, password FROM \"User\" WHERE name=? AND email=?";
+    private static String GET_USER_BY_EMAIL =
+            "SELECT id, name, created_at, role, password FROM \"User\" WHERE email=?";
     private static String REMOVE_USER_BY_ID =
             "delete from \"User\" where id=?";
     private static String CREATE_USER_BY_ID =
@@ -44,11 +44,13 @@ public class UserDao {
                 String email = resultSet.getString(2);
                 Timestamp createdAt = resultSet.getTimestamp(3);
                 String role = resultSet.getString(4);
+                String profileImageUrl = resultSet.getString(5);
                 return User.builder()
                         .id(uid)
                         .name(name)
                         .email(email)
                         .createAt(createdAt)
+                        .profileImageUrl(profileImageUrl)
                         .role(role).build();
             }
             return null;
@@ -84,15 +86,14 @@ public class UserDao {
         }
     }
 
-    public User getUserByNameAndEmail(String name, String email) {
+    public User getUserByEmail(String email) {
         try (Connection connection  = dbConnection.getConnection()) {
-            PreparedStatement preparedStatement =  connection.prepareStatement(GET_USER_BY_NAME_AND_EMAIL);
-            preparedStatement.setString(1, name);
-            preparedStatement.setString(2, email);
+            PreparedStatement preparedStatement =  connection.prepareStatement(GET_USER_BY_EMAIL);
+            preparedStatement.setString(1, email);
             ResultSet resultSet = preparedStatement.executeQuery();
             if (resultSet.next()){
                 long uid = resultSet.getLong(1);
-                //String email = resultSet.getString(2);
+                String name = resultSet.getString(2);
                 Timestamp createdAt = resultSet.getTimestamp(3);
                 String role = resultSet.getString(4);
                 String password = resultSet.getString(5);

--- a/src/main/java/com/dudoji/spring/models/domain/User.java
+++ b/src/main/java/com/dudoji/spring/models/domain/User.java
@@ -21,4 +21,5 @@ public class User {
     private Date createAt;
     private String provider;
     private String providerId;
+    private String profileImageUrl;
 }

--- a/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
+++ b/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
@@ -37,7 +37,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
         // Get Information from Outside Server
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String provider = userRequest.getClientRegistration().getRegistrationId();
-        String provider_id = null, email = null, name = null;
+        String provider_id = null, email = null, name = null, profileImageUrl = null;
         switch (provider) {
             // TODO: Change
             case "google":
@@ -47,6 +47,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
                 Map<String, Object> kakaoAccount = oAuth2User.getAttribute("kakao_account");
                 email = (String) kakaoAccount.get("email");
                 Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+                profileImageUrl = (String) profile.get("profile_image_url");
                 if (profile != null) { name = (String) profile.get("nickname"); }
                 break;
             case "naver":
@@ -62,6 +63,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
         }
 
         User user = userDao.getUserByName(name);
+
         if (user == null) {
             user = User.builder()
                     .name(name)
@@ -69,6 +71,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
                     .password(password)
                     // provider는 조정 후
                     .role(role)
+                    .profileImageUrl(profileImageUrl)
                     .build();
             userDao.createUserByUser(user);
         }

--- a/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
+++ b/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
@@ -62,7 +62,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException(new OAuth2Error("invalid_token"), "ProviderId not found");
         }
 
-        User user = userDao.getUserByName(name);
+        User user = userDao.getUserByNameAndEmail(name, email);
 
         if (user == null) {
             user = User.builder()

--- a/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
+++ b/src/main/java/com/dudoji/spring/security/PrincipalOauth2UserService.java
@@ -62,7 +62,7 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
             throw new OAuth2AuthenticationException(new OAuth2Error("invalid_token"), "ProviderId not found");
         }
 
-        User user = userDao.getUserByNameAndEmail(name, email);
+        User user = userDao.getUserByEmail(email);
 
         if (user == null) {
             user = User.builder()

--- a/src/main/java/com/dudoji/spring/service/UserInfoService.java
+++ b/src/main/java/com/dudoji/spring/service/UserInfoService.java
@@ -1,0 +1,24 @@
+package com.dudoji.spring.service;
+
+import com.dudoji.spring.models.dao.UserDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+/**
+ * UserInfoService
+ * This class is responsible for all service logic related to user information.
+ *
+ * <ul>
+ *     <li>Get User Profile Image</li>
+ * </ul>
+ */
+@Service
+public class UserInfoService {
+
+    @Autowired
+    UserDao userDao;
+
+    public String getProfileImage(long uid) {
+        return userDao.getProfileImageUrl(uid);
+    }
+}

--- a/src/main/java/com/dudoji/spring/service/UserInfoService.java
+++ b/src/main/java/com/dudoji/spring/service/UserInfoService.java
@@ -19,6 +19,14 @@ public class UserInfoService {
     UserDao userDao;
 
     public String getProfileImage(long uid) {
-        return userDao.getProfileImageUrl(uid);
+        return userDao.getUserById(uid).getProfileImageUrl();
+    }
+
+    public String getUsername(long uid) {
+        return userDao.getUserById(uid).getName();
+    }
+
+    public String getEmail(long uid) {
+        return userDao.getUserById(uid).getEmail();
     }
 }


### PR DESCRIPTION
closed #35 

### 설명
- 유저의 이미지 url 을 받아옵니다.
- 처음 로그인 할 때 함께 디비에 저장이 되고 이후 원할 때마다 호출 할 수 있습니다.
- 해당 엔드포인트는 /api/user/info/get/profile_image 입니다.
- 이에 따라 db 구조에 변화가 있습니다.
- 또한, 동명이인일 경우 로그인이 제한 될 수 있어 User 테이블에 name UNIQUE 조건을 제거했습니다.

### 이후 필요할 기능들
- 사진을 원할 때마다 교체할 수 있도록 해야겠습니다.
- 현재는 한 번 저장하고 교체하는 기능이 없습니다.
- 또한, 사진을 가져온 해당 소셜의 사진과 계속 연동을 할 것인지, 한 번만 사진 정보를 받아오고 독립적으로 움직일 건 지 얘기가 필요해 보입니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
