### PR TITLE
Refactor follow feature to clarify follower/following logic

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/FollowController.java
+++ b/src/main/java/com/dudoji/spring/controller/FollowController.java
@@ -21,26 +21,36 @@ public class FollowController {
     private FollowService followService;
 
     @GetMapping("")
-    public ResponseEntity<List<User>> getFollow(
+    public ResponseEntity<List<User>> getFollowing(
             @AuthenticationPrincipal PrincipalDetails principalDetails
     ) {
         if (principalDetails == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
-        List<User> result = followService.getFollowersById(principalDetails.getUid());
-        log.info("getFollowersById({})", result);
+        List<User> result = followService.getFollowingById(principalDetails.getUid());
+        return ResponseEntity.ok(result);
+    }
+
+    @GetMapping("/follwer")
+    public ResponseEntity<List<User>> getFollowers(
+            @AuthenticationPrincipal PrincipalDetails principalDetails
+    ) {
+        if (principalDetails == null) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
+        }
+        List<User> result = followService.getFollowerById(principalDetails.getUid());
         return ResponseEntity.ok(result);
     }
 
     @DeleteMapping("/{userId}")
-    public ResponseEntity<String> deleteFollow(
+    public ResponseEntity<String> deleteFollowing(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long userId
     ) {
         if (principalDetails == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
-        if (followService.deleteFollow(principalDetails.getUid(), userId)) {
+        if (followService.deleteFollowing(principalDetails.getUid(), userId)) {
             return ResponseEntity.status(HttpStatus.OK).body("Delete Success");
         }
         else {
@@ -49,14 +59,14 @@ public class FollowController {
     }
 
     @PostMapping("/{userId}")
-    public ResponseEntity<String> createFollow(
+    public ResponseEntity<String> createFollowing(
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @PathVariable Long userId
     ) {
         if (principalDetails == null) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(null);
         }
-        if (followService.createFollowById(principalDetails.getUid(), userId)) {
+        if (followService.createFollowing(principalDetails.getUid(), userId)) {
             return ResponseEntity.status(HttpStatus.OK).body("Create Success");
         }
         else {

--- a/src/main/java/com/dudoji/spring/models/dao/FollowDao.java
+++ b/src/main/java/com/dudoji/spring/models/dao/FollowDao.java
@@ -1,27 +1,22 @@
 package com.dudoji.spring.models.dao;
 
-import com.dudoji.spring.models.DBConnection;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.simple.JdbcClient;
-import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
-import java.sql.Connection;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.List;
 
 @Slf4j
 @Repository("FollowDao")
 public class FollowDao {
 
-    private static String GET_FOLLOW_LIST_BY_ID = "SELECT (followee_id) FROM follow WHERE follower_id = ?";
-    private static String CREATE_FOLLOW_BY_ID = "INSERT INTO follow (follower_id, followee_id) VALUES (?, ?)";
-    private static String DELETE_FOLLOW_BY_ID = "DELETE FROM follow WHERE follower_id = ? AND followee_id = ?";
-    private static String IS_FOLLOW_EXIST = "SELECT 1 FROM follow WHERE follower_id = ? AND followee_id = ?";
+    private static String GET_FOLLOWING_LIST_BY_ID = "SELECT (followee_id) FROM follow WHERE follower_id = ?";
+    private static String CREATE_FOLLOWING_BY_ID = "INSERT INTO follow (follower_id, followee_id) VALUES (?, ?)";
+    private static String DELETE_FOLLOWING_BY_ID = "DELETE FROM follow WHERE follower_id = ? AND followee_id = ?";
+    private static String IS_FOLLOWING = "SELECT 1 FROM follow WHERE follower_id = ? AND followee_id = ?";
+
+    private static String GET_FOLLOWER_LIST_BY_ID = "SELECT (follower_id) FROM follow WHERE followee_id = ?";
 
     /**
      * &#064;Deprecated
@@ -35,30 +30,37 @@ public class FollowDao {
     private JdbcClient jdbcClient;
 
     // TODO: 이름 명확하게 할 것
+    public List<Long> getFollowingListByUser(long userId) {
+        return jdbcClient.sql(GET_FOLLOWING_LIST_BY_ID)
+                .param(userId)
+                .query(Long.class)
+                .list();
+    }
+
     public List<Long> getFollowerListByUser(long userId) {
-        return jdbcClient.sql(GET_FOLLOW_LIST_BY_ID)
+        return jdbcClient.sql(GET_FOLLOWER_LIST_BY_ID)
                 .param(userId)
                 .query(Long.class)
                 .list();
     }
 
     public boolean isFollowing(long userId, long followeeId) {
-        return jdbcClient.sql(IS_FOLLOW_EXIST) // TODO: TEST NEEDED
+        return jdbcClient.sql(IS_FOLLOWING) // TODO: TEST NEEDED
                 .param(userId)
                 .param(followeeId)
                 .query()
                 .optionalValue().isPresent();
     }
 
-    public boolean createFollowByUser(long userId, long followeeId) {
-        return jdbcClient.sql(CREATE_FOLLOW_BY_ID)
+    public boolean createFollowingByUser(long userId, long followeeId) {
+        return jdbcClient.sql(CREATE_FOLLOWING_BY_ID)
                 .param(userId)
                 .param(followeeId)
                 .update() > 0;
     }
 
-    public boolean deleteFollowByUser(long userId, long followeeId) {
-        return jdbcClient.sql(DELETE_FOLLOW_BY_ID)
+    public boolean deleteFollowingByUser(long userId, long followeeId) {
+        return jdbcClient.sql(DELETE_FOLLOWING_BY_ID)
                 .param(userId)
                 .param(followeeId)
                 .update() > 0;

--- a/src/main/java/com/dudoji/spring/service/FollowService.java
+++ b/src/main/java/com/dudoji/spring/service/FollowService.java
@@ -17,7 +17,17 @@ public class FollowService {
     @Autowired
     private UserDao userDao;
 
-    public List<User> getFollowersById(long userId) {
+    public List<User> getFollowingById(long userId) {
+        List<Long> userIdList = followDao.getFollowingListByUser(userId);
+        List<User> userList = new ArrayList<>(userIdList.size());
+        for (Long friendId : userIdList) {
+            userList.add(userDao.getUserById(friendId));
+        }
+
+        return userList;
+    }
+
+    public List<User> getFollowerById(long userId) {
         List<Long> userIdList = followDao.getFollowerListByUser(userId);
         List<User> userList = new ArrayList<>(userIdList.size());
         for (Long friendId : userIdList) {
@@ -27,12 +37,12 @@ public class FollowService {
         return userList;
     }
 
-    public boolean createFollowById(long userId, long followeeId) {
-        return followDao.createFollowByUser(userId, followeeId);
+    public boolean createFollowing(long userId, long followeeId) {
+        return followDao.createFollowingByUser(userId, followeeId);
     }
 
-    public boolean deleteFollow(long userId, long followeeId) {
-        return followDao.deleteFollowByUser(userId, followeeId);
+    public boolean deleteFollowing(long userId, long followeeId) {
+        return followDao.deleteFollowingByUser(userId, followeeId);
     }
 
     public List<User> getRecommendedFollow(String email) {

--- a/src/test/java/com/dudoji/spring/dao/DBtest/DBTestBase.java
+++ b/src/test/java/com/dudoji/spring/dao/DBtest/DBTestBase.java
@@ -12,6 +12,6 @@ public class DBTestBase {
     @ServiceConnection
     static PostgreSQLContainer<?> isolated =
             new PostgreSQLContainer<>("postgres:17.4-alpine")
-                    .withInitScript("static/sql/schema.sql")
+                    .withInitScripts("static/sql/schema.sql", "static/sql/data.sql")
                     .withReuse(true);
 }

--- a/src/test/java/com/dudoji/spring/dao/FollowDaoTest.java
+++ b/src/test/java/com/dudoji/spring/dao/FollowDaoTest.java
@@ -24,18 +24,32 @@ public class FollowDaoTest extends DBTestBase {
     @Test
     void createFollowAndCheck() {
         // 102가 101 팔로우
-        boolean result = followDao.createFollowByUser(101, 102);
+        boolean result = followDao.createFollowingByUser(101, 102);
         assertTrue(result);
 
         assertTrue(followDao.isFollowing(101, 102));
-        List<Long> getFollowerListByUser = followDao.getFollowerListByUser(101);
+        List<Long> getFollowerListByUser = followDao.getFollowingListByUser(101);
         assertEquals(1, getFollowerListByUser.size());
 
-        boolean result2 = followDao.deleteFollowByUser(101, 102);
+        boolean result2 = followDao.deleteFollowingByUser(101, 102);
         assertTrue(result2);
 
-        List<Long> getFollowerListByUserAfterDelete = followDao.getFollowerListByUser(101);
+        List<Long> getFollowerListByUserAfterDelete = followDao.getFollowingListByUser(101);
         assertTrue(getFollowerListByUserAfterDelete.isEmpty());
 
+    }
+
+    @Test
+    void followerTest() {
+        followDao.createFollowingByUser(101, 102);
+        followDao.createFollowingByUser(103, 102);
+        followDao.createFollowingByUser(104, 102);
+
+        List<Long> followerListByUser = followDao.getFollowerListByUser(102);
+
+        assertEquals(3, followerListByUser.size());
+        assertTrue(followerListByUser.contains(101L));
+        assertTrue(followerListByUser.contains(103L));
+        assertTrue(followerListByUser.contains(104L));
     }
 }


### PR DESCRIPTION
Renamed methods and SQL queries to distinguish between 'follower' and 'following' relationships. Updated controller, service, and DAO layers to use clearer naming conventions. Added new endpoint for retrieving followers and improved test coverage for both following and follower functionalities.

closed #80 

### 설명
- 기존 follower로 이름이 혼동이 될 법한 부분이 있어서 수정했습니다.
- follower는 기존 주소에 /follower 만 적으면 되도록 구성했습니다.
- 팔로잉 팔로우 모두 발견할 수 있게 되었습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
