### PR TITLE
Feature/issue 91

### DIFF
--- a/src/main/java/com/dudoji/spring/util/log/SlackAppender.java
+++ b/src/main/java/com/dudoji/spring/util/log/SlackAppender.java
@@ -1,0 +1,42 @@
+package com.dudoji.spring.util.log;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+import lombok.Setter;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Map;
+
+@Setter
+public class SlackAppender extends AppenderBase<ILoggingEvent> {
+
+    private String webhookUrl;
+    private String channel;
+
+    @Override
+    public void start() {
+        if (webhookUrl.isEmpty() || channel.isEmpty()) {
+            addError("SlackAppender is not configured properly. Please set the webhookUrl and channel.");
+            return;
+        }
+        super.start();
+    }
+
+    @Override
+    protected void append(ILoggingEvent event) {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders header = new HttpHeaders();
+        header.setContentType(MediaType.APPLICATION_JSON);
+        Map<String, String> payload = Map.of(
+                "channel", "#" + channel,
+                "username", "dudoji-server",
+                "icon_emoji", ":mouse:",
+                "text", event.getFormattedMessage()
+        );
+        HttpEntity request = new HttpEntity(payload, header);
+        restTemplate.postForEntity(webhookUrl, request, String.class);
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,15 @@
+<configuration>
+    <springProperty scope="context" name="WEBHOOK_URL" source="logging.webhook-url"/>
+    <springProperty scope="context" name="CHANNEL" source="logging.channel"/>
+    <appender name="SlackAppender" class="com.dudoji.spring.util.log.SlackAppender">
+        <webhookUrl>${WEBHOOK_URL}</webhookUrl>
+        <channel>${CHANNEL}</channel>
+    </appender>
+    <appender name="AsyncSlackAppender" class="ch.qos.logback.classic.AsyncAppender">
+        <appender-ref ref="SlackAppender"/>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="AsyncSlackAppender"/>
+    </root>
+</configuration>


### PR DESCRIPTION
closed #91

### 설명
- 올라간 서버의 log를 보기 위해 server에 ssh로 접속해야하는 불편함이 있었기에, 프로젝트 인원 모두가 널리 server log를 볼 수 있게 하고 아카이빙 가능하게 하기 위하여! 다음과 같은 기능을 구현했습니다.
- application.yml에 logging.webhook-url, logging.channel을 통해 설정해주면 거기로 보내도록 web hook을 보내도록 구현했습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
