### PR TITLE
Add RequestLogFilter to log incoming HTTP requests

### DIFF
--- a/src/main/java/com/dudoji/spring/util/log/RequestLogFilter.java
+++ b/src/main/java/com/dudoji/spring/util/log/RequestLogFilter.java
@@ -1,0 +1,27 @@
+package com.dudoji.spring.util.log;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class RequestLogFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
+        log.info(
+                "Request: method={}, uri={}, ip={}, userAgent={}",
+                httpRequest.getMethod(),
+                httpRequest.getRequestURI(),
+                httpRequest.getRemoteAddr(),
+                httpRequest.getHeader(HttpHeaders.USER_AGENT)
+        );
+
+        filterChain.doFilter(servletRequest, servletResponse);
+    }
+}


### PR DESCRIPTION
closed #93

### 설명
- filter를 통하여 모든 요청에 상세 정보를 로그로 찍기 위함입니다.
```
Request: method=GET, uri=/style/base-style.css, ip=0:0:0:0:0:0:0:1, userAgent=Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36
```
- 위와 같이, method, uri, ip, user agent가 로그로 찍힙니다.
- 로그 분석 후 비정상적인 요청에 대한 인사이트를 쌓을 수 있을 것으로 기대됩니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
