### PR TITLE
feature/ISSUE-108 범위로 랜드마크 받아오기

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/LandmarkController.java
+++ b/src/main/java/com/dudoji/spring/controller/LandmarkController.java
@@ -2,6 +2,7 @@ package com.dudoji.spring.controller;
 
 import com.dudoji.spring.dto.landmark.LandmarkRequestDto;
 import com.dudoji.spring.dto.landmark.LandmarkResponseDto;
+import com.dudoji.spring.dto.mapsection.RevealCirclesRequestDto;
 import com.dudoji.spring.models.domain.PrincipalDetails;
 import com.dudoji.spring.service.LandmarkService;
 import lombok.RequiredArgsConstructor;
@@ -26,6 +27,17 @@ public class LandmarkController {
     ){
         return ResponseEntity.ok(
                 landmarkService.getLandmarks(principalDetails.getUid())
+        );
+    }
+
+    ///  Only need lat, lng, radius
+    @GetMapping("/api/user/landmarks/point")
+    public ResponseEntity<List<LandmarkResponseDto>> getLandmarkPoints(
+        @AuthenticationPrincipal PrincipalDetails principalDetails,
+        @RequestBody RevealCirclesRequestDto.RevealCircleDto revealCircleDto
+    ) {
+        return ResponseEntity.ok(
+            landmarkService.getLandmarksCircleRadius(principalDetails.getUid(), revealCircleDto)
         );
     }
 

--- a/src/main/java/com/dudoji/spring/service/LandmarkService.java
+++ b/src/main/java/com/dudoji/spring/service/LandmarkService.java
@@ -3,8 +3,11 @@ package com.dudoji.spring.service;
 import com.dudoji.spring.dto.landmark.LandmarkDetectionDto;
 import com.dudoji.spring.dto.landmark.LandmarkRequestDto;
 import com.dudoji.spring.dto.landmark.LandmarkResponseDto;
+import com.dudoji.spring.dto.mapsection.RevealCirclesRequestDto;
 import com.dudoji.spring.models.dao.LandmarkDao;
 import com.dudoji.spring.models.domain.Landmark;
+import com.dudoji.spring.util.BitmapUtil;
+
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -46,5 +49,26 @@ public class LandmarkService {
 
     public void putLandmark(Long landmarkId, LandmarkRequestDto landmarkRequestDto) {
         landmarkDao.putLandmark(new Landmark(landmarkId, landmarkRequestDto));
+    }
+
+    /**
+     * 주어진 좌표에 기반하여 Bounding Box 를 구성하여 정보를 받아오는 함수
+     * @param revealCircleDto 원하는 곳의 좌표를 담은 곳
+     * @return List - LandmarkResponseDto
+     */
+    public List<LandmarkResponseDto> getLandmarksCircleRadius(long userId, RevealCirclesRequestDto.RevealCircleDto revealCircleDto) {
+
+        // Calculate lat, lng value based on radius
+        double lat = revealCircleDto.getLat();
+        double lng = revealCircleDto.getLng();
+        double radius = revealCircleDto.getRadius();
+
+        double deltaLat = Math.toDegrees(radius / BitmapUtil.EARTH_RADIUS);
+        double deltaLng = Math.toDegrees(radius / BitmapUtil.EARTH_RADIUS * Math.cos(Math.toRadians(revealCircleDto.getLat())));
+
+		return landmarkDao.getLandmarksCircleRadius(userId, lat, lng, deltaLat, deltaLng)
+			.stream()
+			.map(LandmarkResponseDto::new)
+			.toList();
     }
 }


### PR DESCRIPTION
closed #108 

### 설명
- 특정 좌표와 범위(m 단위)로 주면 해당하는 모든 랜드마크를 가져옵니다.
- Body에 lat, lng, radius를 JSON 형식으로 넣어주면 값을 반환합니다.
- 기존 getLandmarks와 동일하게 isDetected도 포함되어 넘겨줍니다.
- 다만, 원으로 탐색하지는 않습니다. 이유는, 새로운 API를 도입하지 않는 이상 원 탐색을 하려면 쿼리를 여러번 날려야 합니다.
- 그렇기 때문에 간단하게 구현하기 위하여 네모네모로 탐색합니다.
- 감사합니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
