### PR TITLE
feature/ISSUE-112 랜드마크 사진 분리

### DIFF
--- a/src/main/java/com/dudoji/spring/dto/landmark/LandmarkRequestDto.java
+++ b/src/main/java/com/dudoji/spring/dto/landmark/LandmarkRequestDto.java
@@ -6,6 +6,7 @@ public record LandmarkRequestDto(
         String placeName,
         String address,
         String content,
-        String imageUrl
+        String mapImageUrl,
+		String detailImageUrl
 ) {
 }

--- a/src/main/java/com/dudoji/spring/dto/landmark/LandmarkResponseDto.java
+++ b/src/main/java/com/dudoji/spring/dto/landmark/LandmarkResponseDto.java
@@ -10,7 +10,8 @@ public record LandmarkResponseDto(
         String placeName,
         String address,
         String content,
-        String imageUrl,
+        String mapImageUrl,
+        String detailImageUrl,
         double radius,
         boolean isDetected
 ) {
@@ -22,7 +23,9 @@ public record LandmarkResponseDto(
             landmark.getPlaceName(),
             landmark.getAddress(),
             landmark.getContent(),
-            landmark.getImageUrl(), landmark.isDetected() ? LandmarkConfig.LANDMARK_DETECTED_RADIUS : LandmarkConfig.LANDMARK_UNDETECTED_RADIUS,
+            landmark.getMapImageUrl(),
+            landmark.getDetailImageUrl(),
+            landmark.isDetected() ? LandmarkConfig.LANDMARK_DETECTED_RADIUS : LandmarkConfig.LANDMARK_UNDETECTED_RADIUS,
             landmark.isDetected());
         }
 }

--- a/src/main/java/com/dudoji/spring/models/domain/Landmark.java
+++ b/src/main/java/com/dudoji/spring/models/domain/Landmark.java
@@ -11,7 +11,8 @@ public class Landmark {
     private double lat;
     private double lng;
     private String content;
-    private String imageUrl;
+    private String mapImageUrl;
+    private String detailImageUrl;
     private String placeName;
     private String address;
     private boolean isDetected;
@@ -21,7 +22,8 @@ public class Landmark {
                 landmarkRequestDto.lat(),
                 landmarkRequestDto.lng(),
                 landmarkRequestDto.content(),
-                landmarkRequestDto.imageUrl(),
+                landmarkRequestDto.mapImageUrl(),
+                landmarkRequestDto.detailImageUrl(),
                 landmarkRequestDto.placeName(),
                 landmarkRequestDto.address(),
                 false

--- a/src/main/java/com/dudoji/spring/service/LandmarkService.java
+++ b/src/main/java/com/dudoji/spring/service/LandmarkService.java
@@ -33,7 +33,8 @@ public class LandmarkService {
                 landmarkRequestDto.lat(),
                 landmarkRequestDto.lng(),
                 landmarkRequestDto.content(),
-                landmarkRequestDto.imageUrl(),
+                landmarkRequestDto.mapImageUrl(),
+                landmarkRequestDto.detailImageUrl(),
                 landmarkRequestDto.placeName(),
                 landmarkRequestDto.address()
         );

--- a/src/main/resources/static/js/landmarks-management.js
+++ b/src/main/resources/static/js/landmarks-management.js
@@ -1,10 +1,14 @@
 // Admin's landmarks management script
-
 const modal = document.getElementById('modal');
 const modalTitle = document.getElementById('modal-title');
-const modalImagePreview = document.getElementById('modal-imagePreview');
-const modalImageUrl = document.getElementById('modal-imageUrl'); // 서버로부터 받은 최종 이미지 URL을 저장할 hidden input
-const modalImageFile = document.getElementById('modal-imageFile'); // 파일 선택 input
+
+const modalMapImagePreview = document.getElementById('modal-mapImagePreview');
+const modalMapImageUrl = document.getElementById('modal-mapImageUrl'); // 서버로부터 받은 최종 이미지 URL을 저장할 hidden input
+const modalMapImageFile = document.getElementById('modal-mapImageFile'); // 파일 선택 input
+
+const modalDetailImagePreview = document.getElementById('modal-detailImagePreview');
+const modalDetailImageUrl = document.getElementById('modal-detailImageUrl'); // 서버로부터 받은 최종 이미지 URL을 저장할 hidden input
+const modalDetailImageFile = document.getElementById('modal-detailImageFile'); // 파일 선택 input
 
 let modalMode = 'none';
 let selectedLandmarkId = null;
@@ -22,12 +26,20 @@ function openModal(mode, landmark = null) {
         document.querySelector('[name="address"]').value = landmark.address;
 
         // 기존 이미지 URL이 있을 경우 preview
-        if (landmark.imageUrl) {
+        if (landmark.mapImageUrl) {
             const preview = document.getElementById('modal-imagePreview');
             preview.src = landmark.imageUrl;
             preview.style.display = 'block';
-            document.getElementById('modal-imageUrl').value = landmark.imageUrl;
-            document.getElementById('modal-existingImageUrl').value = landmark.imageUrl;
+            document.getElementById('modal-mapImageUrl').value = landmark.mapImageUrl;
+            document.getElementById('modal-existingMapImageUrl').value = landmark.mapImageUrl;
+        }
+
+        if (landmark.detailImageUrl) {
+            const preview = document.getElementById('modal-detailImagePreview');
+            preview.src = landmark.detailImageUrl;
+            preview.style.display = 'block';
+            document.getElementById('modal-detailImageUrl').value = landmark.detailImageUrl;
+            document.getElementById('modal-existingDetailImageUrl').value = landmark.detailImageUrl;
         }
     }
     modal.style.display = 'block';
@@ -43,32 +55,27 @@ function closeModal() {
 document.getElementById('infoForm').addEventListener('submit', async function(event) {
     event.preventDefault();
 
-    const file = modalImageFile.files[0];
-    let finalImageUrl = modalImageUrl.value;
+    const mapImageFile = modalMapImageFile.files[0];
+    let finalMapImageUrl = modalMapImageUrl.value;
 
-    if (file) { // new Image
-        const imageFormData = new FormData();
-        imageFormData.append("image", file);
+    const detailImageFile = modalDetailImageFile.files[0];
+    let finalDetailImageUrl = modalDetailImageUrl.value;
 
-        try {
-            const uploadResponse = await fetch('/api/admin/images/landmarks', {
-                method: 'POST',
-                body: imageFormData
-            });
-
-            if (!uploadResponse.ok) {
-                // 예외처리
-                const errorText = await uploadResponse.text();
-                throw new Error(`Failed upload: ${uploadResponse.status} - ${errorText}`);
-            }
-
-            finalImageUrl = await uploadResponse.text();
-        } catch (error) {
-            console.error('이미지 업로드 오류:', error);
-            alert('이미지 업로드 중 오류가 발생했습니다: ' + error.message);
+    try {
+        if (mapImageFile) {
+            finalMapImageUrl = await uploadImage(mapImageFile, '/api/admin/images/landmarks/map');
         }
+        if (detailImageFile) {
+            finalDetailImageUrl = await uploadImage(detailImageFile, '/api/admin/images/landmarks/detail');
+        }
+    } catch (error) {
+        console.error('이미지 업로드 오류:', error);
+        alert('이미지 업로드 중 오류가 발생했습니다: ' + error.message);
+        return;
     }
-    modalImageUrl.value = finalImageUrl;
+
+    modalMapImageUrl.value = finalMapImageUrl;
+    modalDetailImageUrl.value = finalDetailImageUrl;
 
     if (modalMode === 'add') {
         addLandmark();
@@ -104,6 +111,8 @@ function sendLandmarkData(url, method) {
     const formData = new FormData(document.getElementById("infoForm"));
     const data = Object.fromEntries(formData.entries());
 
+    console.log(JSON.stringify(data, null, 2)); // Log the data to the console
+
     fetch(url, {
         method: method,
         headers: {
@@ -115,11 +124,42 @@ function sendLandmarkData(url, method) {
     });
 }
 
-function previewImage(event) {
+// TODO: 적용 on detail
+function previewImage(event, target) {
     const reader = new FileReader();
-    reader.onload = function(){
-        modalImagePreview.src = reader.result;
-        modalImagePreview.style.display = 'block';
-    };
-    reader.readAsDataURL(event.target.files[0]);
+    switch (target) {
+        case 0:
+            reader.onload = function(){
+                modalMapImagePreview.src = reader.result;
+                modalMapImagePreview.style.display = 'block';
+            };
+            reader.readAsDataURL(event.target.files[0]);
+            break;
+        case 1:
+            reader.onload = function(){
+                modalDetailImagePreview.src = reader.result;
+                modalDetailImagePreview.style.display = 'block';
+            };
+            reader.readAsDataURL(event.target.files[0]);
+            break;
+    }
+}
+
+async function uploadImage(file, endpoint) {
+    if (!file) return null;
+
+    const formData = new FormData();
+    formData.append("image", file);
+
+    const res = await fetch(endpoint, {
+        method: "POST",
+        body: formData
+    });
+
+    if (!res.ok) {
+        const errText = await res.text();
+        throw new Error(`Upload failed: ${res.status} – ${errText}`);
+    }
+
+    return res.text();
 }

--- a/src/main/resources/static/sql/schema.sql
+++ b/src/main/resources/static/sql/schema.sql
@@ -265,3 +265,8 @@ CREATE TABLE Inventory (
                                    REFERENCES Item(itemId)
                                    ON DELETE CASCADE
 );
+
+ALTER TABLE Landmark
+    RENAME COLUMN imageUrl TO mapImageUrl;
+
+ALTER TABLE Landmark ADD COLUMN detailImageUrl VARCHAR;

--- a/src/main/resources/templates/admin_landmarks.html
+++ b/src/main/resources/templates/admin_landmarks.html
@@ -22,7 +22,8 @@
             <th>landmark id</th>
             <th>PlaceName</th>
             <th>latlng</th>
-            <th>image</th>
+            <th>Map Image</th>
+            <th>Detail Image</th>
             <th>content</th>
             <th>address</th>
             <th>function</th>
@@ -33,7 +34,8 @@
             <td th:text="${landmark.landmarkId()}"></td>
             <td th:text="${landmark.placeName()}"></td>
             <td th:text="${landmark.lat} + ', ' + ${landmark.lng}"></td>
-            <td><img th:src="@{${landmark.imageUrl()}}" style="height:64px"/></td>
+            <td><img th:src="@{${landmark.mapImageUrl()}}" style="height:64px"/></td>
+            <td><img th:src="@{${landmark.detailImageUrl()}}" style="height:64px"/></td>
             <td th:text="${landmark.content()}"></td>
             <td th:text="${landmark.address()}"></td>
             <td>
@@ -61,12 +63,19 @@
             <input type="number" name="lng" required step="any">
         </label><br><br>
 
-        <label>Image:
-            <input type="file" name="imageFile" id="modal-imageFile" accept="image/*" onchange="previewImage(event)">
+        <label>Map Image:
+            <input type="file" id="modal-mapImageFile" accept="image/*" onchange="previewImage(event, 0)">
         </label><br>
-        <input type="hidden" name="imageUrl" id="modal-imageUrl">
-        <img id="modal-imagePreview" src="#" alt="Image Preview" style="max-width:100px; max-height:100px; margin-top:10px; border:1px solid #ddd; display:none;"><br><br>
-        <input type="hidden" name="existingImageUrl" id="modal-existingImageUrl">
+        <input type="hidden" name="mapImageUrl" id="modal-mapImageUrl">
+        <img id="modal-mapImagePreview" src="#" alt="Image Preview" style="max-width:100px; max-height:100px; margin-top:10px; border:1px solid #ddd; display:none;"><br><br>
+        <input type="hidden" id="modal-existingMapImageUrl">
+
+        <label>Detail Image:
+            <input type="file" id="modal-detailImageFile" accept="image/*" onchange="previewImage(event, 1)">
+        </label><br>
+        <input type="hidden" name="detailImageUrl" id="modal-detailImageUrl">
+        <img id="modal-detailImagePreview" src="#" alt="Image Preview" style="max-width:100px; max-height:100px; margin-top:10px; border:1px solid #ddd; display:none;"><br><br>
+        <input type="hidden" id="modal-existingDetailImageUrl">
 
         <label>Content:
             <textarea name="content" rows="3" required></textarea>


### PR DESCRIPTION
closed #112 

### 설명
- Map에서 사용하는 랜드마크 이미지와 상세정보에서 이미지를 다르게 합니다.
<img width="1117" height="555" alt="{D0EC5A3A-EDAC-419D-8E13-657BBAE63603}" src="https://github.com/user-attachments/assets/e93e60f1-446b-4145-a503-c7709a306ff4" />
예시 사진


이렇게 분리가 잘 되고, 어드민 페이지도 수정을 해놨습니다.  


js가 어려워 오래걸렸네요  


변수는 mapImageUrl, detailImageUrl 로 구성되어 있습니다   




### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
