### PR TITLE
feature/ISSUE-114 : 좋아요 순으로 Pin Pageable 기능 구현

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/PinController.java
+++ b/src/main/java/com/dudoji/spring/controller/PinController.java
@@ -34,9 +34,11 @@ public class PinController {
             @AuthenticationPrincipal PrincipalDetails principalDetails,
             @RequestParam double radius, // TODO: PARAM? OR PATH VARIABLE?
             @RequestParam double lat,
-            @RequestParam double lng
+            @RequestParam double lng,
+            @RequestParam int limit,
+            @RequestParam int offset
     ) {
-        List<PinResponseDto> pins = pinService.getClosePins(radius, lat, lng, principalDetails.getUid());
+        List<PinResponseDto> pins = pinService.getClosePins(radius, lat, lng, principalDetails.getUid(), limit, offset);
         pinService.refreshLikes(); // TODO: CHANGE
         return ResponseEntity.status(HttpStatus.OK).body(pins);
     }
@@ -61,9 +63,11 @@ public class PinController {
 
     @GetMapping("/mine")
     public ResponseEntity<List<PinResponseDto>> getMyPins(
-            @AuthenticationPrincipal PrincipalDetails principalDetails
+            @AuthenticationPrincipal PrincipalDetails principalDetails,
+            @RequestParam int limit,
+            @RequestParam int offset
     ) {
-        List<PinResponseDto> pins = pinService.getMyPins(principalDetails.getUid());
+        List<PinResponseDto> pins = pinService.getMyPins(principalDetails.getUid(), limit, offset);
         return ResponseEntity.status(HttpStatus.OK).body(pins);
     }
 }

--- a/src/main/java/com/dudoji/spring/dto/pin/PinResponseDto.java
+++ b/src/main/java/com/dudoji/spring/dto/pin/PinResponseDto.java
@@ -40,5 +40,6 @@ public class PinResponseDto {
         this.placeName = pin.getPlaceName();
         this.address = pin.getAddress();
         this.pinSkinId = pin.getPinSkinId();
+        this.likeCount = pin.getLikes();
     }
 }

--- a/src/main/java/com/dudoji/spring/models/dao/PinDao.java
+++ b/src/main/java/com/dudoji/spring/models/dao/PinDao.java
@@ -3,6 +3,7 @@ package com.dudoji.spring.models.dao;
 import com.dudoji.spring.models.domain.Pin;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.simple.JdbcClient;
 import org.springframework.stereotype.Repository;
 
@@ -16,31 +17,67 @@ public class PinDao {
     @Autowired
     private JdbcClient jdbcClient;
 
-    private static final String CREATE_PIN_BY_REQUEST = "INSERT INTO pin (userId, lat, lng, content, createdAt, imageUrl, placeName, address, skinid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id";
+    private static final String CREATE_PIN_BY_REQUEST = "INSERT INTO Pin (userId, lat, lng, content, createdAt, imageUrl, placeName, address, skinid) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?) RETURNING id";
 
-    private static final String GET_CLOSE_PIN_BY_MIN_MAX = "SELECT id, userId, lat, lng, content, createdAt, imageUrl, placeName, address, skinid " +
-            "FROM pin " +
-            "WHERE lat BETWEEN ? AND ? " +
-            "AND lng BETWEEN ? AND ?";
+    // private static final String GET_CLOSE_PIN_BY_MIN_MAX_WITH_LIMIT = "SELECT id, userId, lat, lng, content, createdAt, imageUrl, placeName, address, skinid " +
+    //         "FROM Pin " +
+    //         "WHERE lat BETWEEN ? AND ? " +
+    //         "AND lng BETWEEN ? AND ? " +
+    //         "LIMIT ? OFFSET ?";
 
-    private static final String GET_ALL_PIN_BY_USER_ID = "SELECT id, lat, lng, content, createdAt, imageUrl, placeName, address, skinid " +
-            "FROM pin " +
-            "WHERE userId = ?";
+    private static final String GET_CLOSE_PIN_BY_MIN_MAX_WITH_LIMIT = """
+        SELECT p.id, p.userId, p.lat, p.lng, p.content, p.createdAt, p.imageUrl, p.placeName, p.address, p.skinId, lc.likecount
+        FROM Pin AS p 
+        LEFT JOIN likecounts lc ON p.id = lc.pinId 
+        WHERE p.lat BETWEEN ? AND ? 
+        AND p.lng BETWEEN ? AND ? 
+        ORDER BY lc.likecount DESC NULLS LAST
+        LIMIT ? OFFSET ?
+    """;
+
+    // private static final String GET_ALL_PIN_BY_USER_ID_WITH_LIMIT = "SELECT id, userId, lat, lng, content, createdAt, imageUrl, placeName, address, skinid " +
+    //         "FROM Pin " +
+    //         "WHERE userId = ? " +
+    //         "LIMIT ? OFFSET ?";
+
+    private static final String GET_ALL_PIN_BY_USER_ID_WITH_LIMIT = """
+        SELECT p.id, p.userId, p.lat, p.lng, p.content, p.createdAt, p.imageUrl, p.placeName, p.address, p.skinId, lc.likecount
+        FROM Pin AS p
+        LEFT JOIN likecounts lc ON p.id = lc.pinId 
+        WHERE userId = ? 
+        ORDER BY lc.likecount DESC NULLS LAST
+        LIMIT ? OFFSET ?
+    """;
 
     private static final String GET_NUM_OF_PIN_BY_USER_ID = """
             SELECT count(1)
-            FROM pin
+            FROM Pin
             WHERE userId = :userId;
             """;
 
     private static final String GET_NUM_OF_PIN_BY_USER_ID_AND_DATE = """
             SELECT count(1)
-            FROM pin
+            FROM Pin
             WHERE
             userId = :userId AND
             createdAt >= :startDate AND
             createdAt < :endDate
             """;
+
+    private final RowMapper<Pin> PinMapper = (rs, rowNum) -> new Pin(
+        rs.getDouble("lat"),
+        rs.getDouble("lng"),
+        rs.getLong("id"),
+        rs.getLong("userId"),
+        rs.getTimestamp("createdAt").toLocalDateTime(),
+        rs.getString("content"),
+        rs.getString("imageUrl"),
+        rs.getString("placeName"),
+        rs.getString("address"),
+        rs.getLong("skinId"),
+        rs.getInt("likecount")
+    );
+
     /**
      * Create New Pin Content
      *
@@ -71,46 +108,26 @@ public class PinDao {
      */
     public List<Pin> getClosePins(
             double minLat, double minLng,
-            double maxLat, double maxLng) {
+            double maxLat, double maxLng,
+        int limit, int offset) {
 
-        return jdbcClient.sql(GET_CLOSE_PIN_BY_MIN_MAX)
+        return jdbcClient.sql(GET_CLOSE_PIN_BY_MIN_MAX_WITH_LIMIT)
                 .param(minLat)
                 .param(maxLat)
                 .param(minLng)
                 .param(maxLng)
-                .query((rs, rowNum) ->
-                        Pin.builder()
-                                .pinId(rs.getLong("id"))
-                                .userId(rs.getLong("userId"))
-                                .lat(rs.getDouble("lat"))
-                                .lng(rs.getDouble("lng"))
-                                .content(rs.getString("content"))
-                                .imageUrl(rs.getString("imageUrl"))
-                                .createdDate(rs.getTimestamp("createdAt").toLocalDateTime())
-                                .placeName(rs.getString("placeName"))
-                                .address(rs.getString("address"))
-                                .pinSkinId(rs.getLong("skinid"))
-                                .build())
+                .param(limit)
+                .param(offset)
+                .query(PinMapper)
                 .list();
     }
 
-    public List<Pin> getALlPinsByUserId(long userId) {
-        return jdbcClient.sql(GET_ALL_PIN_BY_USER_ID)
+    public List<Pin> getALlPinsByUserId(long userId, int limit, int offset) {
+        return jdbcClient.sql(GET_ALL_PIN_BY_USER_ID_WITH_LIMIT)
                 .param(userId)
-                .query((rs, rowNum) ->
-                        Pin.builder()
-                            .pinId(rs.getLong("id"))
-                            .userId(userId)
-                            .lat(rs.getDouble("lat"))
-                            .lng(rs.getDouble("lng"))
-                            .content(rs.getString("content"))
-                            .imageUrl(rs.getString("imageUrl"))
-                            .createdDate(
-                                    rs.getTimestamp("createdAt").toLocalDateTime())
-                            .placeName(rs.getString("placeName"))
-                            .address(rs.getString("address"))
-                            .pinSkinId(rs.getLong("skinid"))
-                            .build())
+                .param(limit)
+                .param(offset)
+                .query(PinMapper)
                 .list();
     }
 

--- a/src/main/java/com/dudoji/spring/models/domain/Pin.java
+++ b/src/main/java/com/dudoji/spring/models/domain/Pin.java
@@ -1,11 +1,15 @@
 package com.dudoji.spring.models.domain;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
 import java.time.LocalDateTime;
 
 @Data
 @Builder
+@AllArgsConstructor
 public class Pin {
     private double lat;
     private double lng;
@@ -17,4 +21,5 @@ public class Pin {
     private String placeName;
     private String address;
     private Long pinSkinId;
+    private int likes;
 }

--- a/src/test/java/com/dudoji/spring/dao/PinDaoTest.java
+++ b/src/test/java/com/dudoji/spring/dao/PinDaoTest.java
@@ -62,12 +62,13 @@ public class PinDaoTest extends DBTestBase {
 
         List<Pin> pinList = pinDao.getClosePins(
                 lat, lng,
-                lat + 0.3, lng + 0.3
+                lat + 0.3, lng + 0.3,
+            100, 0
         );
 
         assertEquals(2, pinList.size());
 
-        List<Pin> pinListByUserId = pinDao.getALlPinsByUserId(uid);
+        List<Pin> pinListByUserId = pinDao.getALlPinsByUserId(uid, 100, 0);
         assertEquals(2, pinListByUserId.size());
     }
 }


### PR DESCRIPTION
closed #114 

### 설명
- 핀에 페이저블 기능을 구현했습니다.
- 자신의 핀을 가져오는 기능과 주변 핀을 가져올 때 이 기능이 작동합니다.
- 쿼리문의 LIMIT, OFFSET 기능을 사용했습니다.
- 또한, Service 단에서 dto 변환 시 불필요한 코드들을 조정했습니다.
- Pin 도메인의 좋아요 개수를 저장하는 likes 필드를 만들었습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
