### PR TITLE
feature/ISSUE-121: 랜드마크 검색 기능 구현

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/LandmarkController.java
+++ b/src/main/java/com/dudoji/spring/controller/LandmarkController.java
@@ -71,4 +71,11 @@ public class LandmarkController {
         landmarkService.putLandmark(landmarkId, landmarkRequestDto);
         return ResponseEntity.ok("successfully saved");
     }
+
+    @GetMapping("/api/user/landmarks/search")
+    public ResponseEntity<List<LandmarkResponseDto>> getLandmarksByKeyword(
+        @RequestParam String keyword
+    ) {
+        return ResponseEntity.ok(landmarkService.getLandmarksByKeyword(keyword));
+    }
 }

--- a/src/main/java/com/dudoji/spring/service/LandmarkService.java
+++ b/src/main/java/com/dudoji/spring/service/LandmarkService.java
@@ -18,6 +18,8 @@ import java.util.List;
 @Slf4j
 public class LandmarkService {
 
+    public static final int MAX_LANDMARK_SIZE = 10;
+
     @Autowired
     private LandmarkDao landmarkDao;
 
@@ -71,5 +73,13 @@ public class LandmarkService {
 			.stream()
 			.map(LandmarkResponseDto::new)
 			.toList();
+    }
+
+    public List<LandmarkResponseDto> getLandmarksByKeyword(String keyword) {
+        return landmarkDao.getLandmarksByKeyword(keyword)
+            .stream()
+            .limit(MAX_LANDMARK_SIZE)
+            .map(LandmarkResponseDto::new)
+            .toList();
     }
 }


### PR DESCRIPTION
closed #121 

### 설명
- 랜드마크 검색 기능을 구현했습니다.
- 검색은 content, address, placeName 에 대하여 검색을 진행합니다.
- 연관된 결과를 서비스 층에서 10개씩 잘라 보내줍니다.
- 많아졌을 경우를 대비해서 플러그인 도입을 고려해봐야겠습니다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
