### PR TITLE
Feature/issue 133 메타 데이터 받아오기

### DIFF
--- a/src/main/java/com/dudoji/spring/controller/NpcController.java
+++ b/src/main/java/com/dudoji/spring/controller/NpcController.java
@@ -19,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.dudoji.spring.dto.mission.QuestRequestDto;
 import com.dudoji.spring.dto.npc.NpcDto;
+import com.dudoji.spring.dto.npc.NpcMetaDto;
 import com.dudoji.spring.dto.npc.NpcQuestDto;
 import com.dudoji.spring.dto.npc.NpcQuestSimpleDto;
 import com.dudoji.spring.dto.npc.NpcRequestDto;
@@ -180,5 +181,14 @@ public class NpcController {
 	@PreAuthorize("hasRole('admin')")
 	public ResponseEntity<List<NpcSkin>> getAllNpcSkins() {
 		return ResponseEntity.ok(npcService.getAllNpcSkins());
+	}
+
+
+	@GetMapping("/api/user/npcs/meta")
+	@PreAuthorize("hasRole('admin')")
+	public ResponseEntity<List<NpcMetaDto>> getNpcMetaData(
+		@AuthenticationPrincipal PrincipalDetails principalDetails
+	) {
+		return ResponseEntity.ok(npcService.getAllNpcMetaData(principalDetails.getUid()));
 	}
 }

--- a/src/main/java/com/dudoji/spring/controller/NpcController.java
+++ b/src/main/java/com/dudoji/spring/controller/NpcController.java
@@ -183,9 +183,10 @@ public class NpcController {
 		return ResponseEntity.ok(npcService.getAllNpcSkins());
 	}
 
-
+	/*
+		meta data
+	 */
 	@GetMapping("/api/user/npcs/meta")
-	@PreAuthorize("hasRole('admin')")
 	public ResponseEntity<List<NpcMetaDto>> getNpcMetaData(
 		@AuthenticationPrincipal PrincipalDetails principalDetails
 	) {

--- a/src/main/java/com/dudoji/spring/dto/npc/NpcDto.java
+++ b/src/main/java/com/dudoji/spring/dto/npc/NpcDto.java
@@ -22,7 +22,8 @@ public class NpcDto {
 			name,
 			null,
 			null,
-			null // 얘네는 값이 없음
+			null, // 얘네는 값이 없음
+			null
 		);
 	}
 

--- a/src/main/java/com/dudoji/spring/dto/npc/NpcMetaDto.java
+++ b/src/main/java/com/dudoji/spring/dto/npc/NpcMetaDto.java
@@ -1,0 +1,10 @@
+package com.dudoji.spring.dto.npc;
+
+public record NpcMetaDto(
+	long npcSkinId,
+	String locationName,
+	String questName,
+	int numOfQuests,
+	int numOfClearedQuests
+) {
+}

--- a/src/main/java/com/dudoji/spring/dto/npc/NpcRequestDto.java
+++ b/src/main/java/com/dudoji/spring/dto/npc/NpcRequestDto.java
@@ -8,6 +8,7 @@ public record NpcRequestDto(
 	String name,
 	String npcScript,
 	String npcDescription,
-	String imageUrl
+	String imageUrl,
+	String questName
 ) {
 }

--- a/src/main/java/com/dudoji/spring/dto/npc/NpcResponseDto.java
+++ b/src/main/java/com/dudoji/spring/dto/npc/NpcResponseDto.java
@@ -8,6 +8,7 @@ public record NpcResponseDto (
 	String name,
 	String npcScript,
 	String npcDescription,
-	String imageUrl
+	String imageUrl,
+	String questName
 ) {
 }

--- a/src/main/java/com/dudoji/spring/models/domain/Npc.java
+++ b/src/main/java/com/dudoji/spring/models/domain/Npc.java
@@ -17,6 +17,7 @@ public class Npc {
 	private String npcScript;
 	private String description;
 	private String imageUrl;
+	private String questName;
 
 	public Npc(NpcRequestDto dto) {
 		this.npcId = dto.npcId();
@@ -27,6 +28,7 @@ public class Npc {
 		this.npcScript = dto.npcScript();
 		this.description = dto.npcDescription();
 		this.imageUrl = dto.imageUrl();
+		this.questName = dto.questName();
 	}
 
 	public NpcResponseDto toNpcResponseDto() {
@@ -38,7 +40,8 @@ public class Npc {
 			name,
 			npcScript,
 			description,
-			imageUrl
+			imageUrl,
+			questName
 		);
 	}
 }

--- a/src/main/java/com/dudoji/spring/service/NpcService.java
+++ b/src/main/java/com/dudoji/spring/service/NpcService.java
@@ -16,6 +16,7 @@ import org.springframework.web.cors.PreFlightRequestHandler;
 import com.dudoji.spring.dto.mission.QuestDetailDto;
 import com.dudoji.spring.dto.mission.QuestRequestDto;
 import com.dudoji.spring.dto.npc.NpcDto;
+import com.dudoji.spring.dto.npc.NpcMetaDto;
 import com.dudoji.spring.dto.npc.NpcQuestDto;
 import com.dudoji.spring.dto.npc.NpcQuestSimpleDto;
 import com.dudoji.spring.dto.npc.NpcQuestStatusDto;
@@ -301,5 +302,14 @@ public class NpcService {
 	 */
 	public boolean deleteNpcSkin(long skinId) {
 		return npcSkinDao.deleteNpcSkin(skinId);
+	}
+
+	/**
+	 * 유저의 정보를 통해 Npc 메타 데이터를 넘겨 받습니다.
+	 * @param userId 해당하는 유저 아이디
+	 * @return NpcMetaDto 의 리스트
+	 */
+	public List<NpcMetaDto> getAllNpcMetaData(long userId) {
+		return npcDao.getNpcMetaData(userId);
 	}
 }

--- a/src/main/resources/static/admin/js/npcs-management.js
+++ b/src/main/resources/static/admin/js/npcs-management.js
@@ -28,6 +28,7 @@ async function loadNpcs() {
             <td>${npc.npcScript}</td>
             <td><img src="${npc.imageUrl}" style="height:64px"/></td>
             <td>${npc.npcSkinId}</td>
+            <td>${npc.questName}</td>
             <td>
                 <button type="button" onclick='openModal("update", ${JSON.stringify(npc)})'>Update</button>
                 <button type="button" onclick="deleteNpc(${npc.npcId})">Delete</button>

--- a/src/main/resources/static/sql/data.sql
+++ b/src/main/resources/static/sql/data.sql
@@ -19,7 +19,7 @@ INSERT INTO public."User" (
       (108, '테스트9', '9@9',   NULL, 'user'::user_role, NULL, NULL, DEFAULT, NULL),
       (109, '테스트10','10@10', NULL, 'user'::user_role, NULL, NULL, DEFAULT, NULL);
 
-INSERT INTO Landmark(landmarkId, lat, lng, placeName, content, imageUrl, address)
+INSERT INTO Landmark(landmarkId, lat, lng, placeName, content, mapImageUrl, address)
 VALUES
     (1, 0, 0, 'test', 'test', 'test', 'test');
 
@@ -33,3 +33,7 @@ INSERT INTO Quest(title, checker, goalValue, unit, questType) VALUES
     ('핀을 꽂아보자!', 'DailyPinQuest', 5, 'COUNT', 'DAILY'),
     ('새로운 랜드마크를 방문하자!', 'NewLandmarkQuest', 5, 'DISTANCE', 'LANDMARK'),
     ('모든 랜드마크를 방문하자!', 'LandmarkCountQuest', 5, 'COUNT', 'LANDMARK');
+
+INSERT INTO Region(regionId, name) VALUES
+    (1, '부산광역시'),
+    (2, '서울특별시');

--- a/src/main/resources/static/sql/schema.sql
+++ b/src/main/resources/static/sql/schema.sql
@@ -213,8 +213,8 @@ ALTER TABLE landmarkDetection RENAME COLUMN user_id TO userId;
 ALTER TABLE landmarkDetection RENAME COLUMN detected_at TO detectedAt;
 
 -- landmark
-ALTER TABLE landmark RENAME COLUMN place_name TO placeName;
-ALTER TABLE landmark RENAME COLUMN image_url TO imageUrl;
+-- ALTER TABLE landmark RENAME COLUMN place_name TO placeName;
+-- ALTER TABLE landmark RENAME COLUMN image_url TO imageUrl;
 
 -- User
 ALTER TABLE "User" RENAME COLUMN provider_id TO providerId;
@@ -304,7 +304,7 @@ CREATE TABLE UserNpcQuestStatus (
                                     userId BIGINT NOT NULL REFERENCES "User"(id) ON DELETE CASCADE ,
                                     questId BIGINT NOT NULL REFERENCES Quest(questId) ON DELETE CASCADE ,
                                     status  quest_progress default 'PROGRESS',
-                                    startedAt TIMESTAMP NOT NULL,
+                                    startedAt TIMESTAMP NOT NULL default now(),
                                     completedAt TIMESTAMP
 );
 
@@ -321,3 +321,6 @@ ALTER TYPE quest_type ADD VALUE 'NPC_SUB';
 ALTER TYPE quest_type ADD VALUE 'NPC_EMERGENCY';
 
 ALTER TABLE "User" ADD COLUMN coin INT DEFAULT 0;
+
+ALTER TABLE Npc ADD COLUMN questName VARCHAR;
+ALTER TABLE NpcQUest ADD UNIQUE (npcId, questId);

--- a/src/main/resources/templates/admin_npcs.html
+++ b/src/main/resources/templates/admin_npcs.html
@@ -23,6 +23,7 @@
             <th>Script</th>
             <th>Image</th>
             <th>Npc Skin Id</th>
+            <th>Quest Name</th>
             <th>Actions</th>
         </tr>
         </thead>

--- a/src/test/java/com/dudoji/spring/dao/MetaDataTest.java
+++ b/src/test/java/com/dudoji/spring/dao/MetaDataTest.java
@@ -1,0 +1,142 @@
+package com.dudoji.spring.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import com.dudoji.spring.dao.DBtest.DBTestBase;
+import com.dudoji.spring.dto.mission.QuestRequestDto;
+import com.dudoji.spring.dto.npc.NpcMetaDto;
+import com.dudoji.spring.models.dao.FollowDao;
+import com.dudoji.spring.models.dao.LikesDao;
+import com.dudoji.spring.models.dao.NpcDao;
+import com.dudoji.spring.models.dao.PinDao;
+import com.dudoji.spring.models.dao.quest.MissionDao;
+import com.dudoji.spring.models.dao.quest.NpcQuestDao;
+import com.dudoji.spring.models.dao.skin.NpcSkinDao;
+import com.dudoji.spring.models.domain.Npc;
+import com.dudoji.spring.models.domain.mission.MissionUnit;
+import com.dudoji.spring.models.domain.mission.QuestType;
+import com.dudoji.spring.models.domain.skin.NpcSkin;
+
+@JdbcTest
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Import({NpcDao.class, NpcQuestDao.class, NpcSkinDao.class, MissionDao.class})
+@TestPropertySource(properties = "SLACK_WEBHOOK_URL=http://test-slack-url.com")
+public class MetaDataTest extends DBTestBase {
+
+	@Autowired
+	NpcDao npcDao;
+	@Autowired
+	NpcQuestDao npcQuestDao;
+	@Autowired
+	NpcSkinDao npcSkinDao;
+	@Autowired
+	MissionDao missionDao;
+
+	Map<Long, List<Long>> npcIdToQuestId = new HashMap<>();
+
+	@BeforeAll
+	public void setUp() {
+		// 스킨 만들기
+		NpcSkin firstNpcSkin = new NpcSkin(1, "TestUrl1", 1);
+		NpcSkin secondNpcSkin = new NpcSkin(2, "TestUrl2", 2);
+
+		npcSkinDao.createNpcSkin(firstNpcSkin);
+		npcSkinDao.createNpcSkin(secondNpcSkin);
+
+		// Npc 만들기
+		Npc firstNpc = new Npc(1, 1.0, 1.0, 1, "First Npc", "First Npc Script", "First Npc Description",
+			"First Npc image Url", "First Npc quest Name");
+		Npc secondNpc = new Npc(2, 1.0, 1.0, 2, "Second Npc", "Second Npc Script", "Second Npc Description",
+			"Second Npc image Url", "Second Npc quest Name");
+		Npc thirdNpc = new Npc(3, 1.0, 1.0, 1, "Third Npc", "Third Npc Script", "Third Npc Description",
+			"Third Npc image Url", "Third Npc quest Name");
+
+		npcDao.createNpc(firstNpc);
+		npcDao.createNpc(secondNpc);
+		npcDao.createNpc(thirdNpc);
+
+		List<Npc> npcs = new ArrayList<>();
+		npcs.add(firstNpc);
+		npcs.add(secondNpc);
+		npcs.add(thirdNpc);
+
+		// 퀘스트 만들기
+		npcs.forEach(npc -> {
+			List<Long> npcQuestIds = new ArrayList<>();
+			for (int i=0; i<5; i++) {
+				QuestRequestDto dto = new QuestRequestDto(
+					npc.getName() + i + "th Quest",
+					"checker",
+					10,
+					MissionUnit.COUNT,
+					QuestType.NPC_MAIN
+				);
+				long questId = missionDao.createQuest(dto);
+				npcQuestIds.add(questId);
+				// 디펜던시 어케하노...
+				npcQuestDao.createNpcQuest(npc.getNpcId(), questId);
+			}
+			npcIdToQuestId.put(npc.getNpcId(), npcQuestIds);
+		});
+	}
+
+	@Test
+	public void QuestMetaDataTest() {
+		/* 메타 데이터 생성 테스트
+		 * 순서
+		 * 0. 유저를 하나 만든다. 이는 schema.sql 에 명시되어 있는 101 유저로 한다.
+		 * 1. Npc 를 만든다. 3번 반복한다.
+		 * 2. 퀘스트를 각 Npc 당 5 개씩 만든다.
+		 * 3. 두 Npc 는 각각 1개와 2개의 퀘스트를 완료한 상태로 한다.
+		 * 4. 나머지 한 Npc 는 퀘스트를 아예 받지 않는다.
+		 * 5. 이후 메타데이터를 받아서 원하는 값과 일치 하는 지 확인한다.
+		 * 6. 원하는 값은 다음과 같다.
+		 * 		a. 행 2개
+		 * 		b. 1 / 5 , 2 / 5 의 퀘스트 완료 진행도
+		 */
+
+		long userId = 101;
+
+		long firstNpcQuestId = npcIdToQuestId.get(1L).getFirst();
+		List<Long> secondNpcQuestIds = npcIdToQuestId.get(2L).subList(0, 2);
+
+		// 진행 중
+		assertTrue(npcQuestDao.setQuestAsProgress(userId, firstNpcQuestId));
+		secondNpcQuestIds.forEach(npcQuestId -> { assertTrue(npcQuestDao.setQuestAsProgress(userId, npcQuestId)); });
+
+		// 진행 중을 성공으로
+		assertTrue(npcQuestDao.setQuestAsCompleted(userId, firstNpcQuestId));
+		secondNpcQuestIds.forEach(npcQuestId -> { assertTrue(npcQuestDao.setQuestAsCompleted(userId, npcQuestId)); });
+
+		// 메타 데이터 받아오기
+		List<NpcMetaDto> result = npcDao.getNpcMetaData(userId);
+		System.out.println(result);
+		assertEquals(2, result.size());
+
+		// 맞는 지 확인
+		assertThat(result)
+			.containsExactlyInAnyOrder(
+				new NpcMetaDto(1L, "부산광역시", "First Npc quest Name", 5, 1),
+				new NpcMetaDto(2L, "서울특별시", "Second Npc quest Name", 5, 2)
+			);
+	}
+}


### PR DESCRIPTION
closed #133 

### 설명
- 각 Npc 별로 퀘스트에 대한 메타 데이터를 받아옵니다.
- 완료한 퀘스트가 0개인 Npc에 대해서는 출력하지 않습니다. 
- 그 이유는 Npc가 있는 해당 랜드마크 방문 시 메인 퀘스트가(랜드마크 방문!) 완료된다고 가정했기 때문입니다.
- Npc 테이블에서 Npc의 name과 questName은 다르게 사용해야 할 듯 하여 새롭게 col 을 추가했습니다.
- 이에 따라 어드민 페이지를 변경했습니다.
- 테스트를 위하여 region (2, '서울특별시') 를 추가했습니다.
- 다음과 같이 날아옵니다.
- 
<img width="420" height="207" alt="{49BFD953-D1CA-49FE-A872-5AF5A018B0FC}" src="https://github.com/user-attachments/assets/0ee092e8-91a7-4a51-bf05-ee5d34c6a675" />


### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
